### PR TITLE
allow authz to receive a constructor of Authorizer

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,45 @@ app.use(
 app.listen(3000);
 ```
 
+### Usage with customized authorizer class
+
+When the authorizer needs the request and response object to check the permission, one can pass the constructor of the customized `Authorizer` class instead of an instance.
+
+```typescript
+import { Enforcer, newEnforcer } from 'casbin';
+import { authz, AuthorizerConstructor } from 'casbin-express-authz';
+import { Request, Response } from 'express';
+
+const app = express();
+
+class MyAuthorizer implements Authorizer {
+  private e: Enforcer;
+  private req: Request;
+  private res: Respons;
+
+  constructor(req:Request, res:Respons, e: Enforcer) {
+    this.e = e;
+    this.req = req
+    this.res = res
+  }
+
+  checkPermission(): Promise<boolean> {
+    // do something
+    return true;
+  }
+}
+const e = newEnforcer('examples/authz_model.conf', 'examples/authz_policy.csv');
+
+app.use(
+  authz({
+    newEnforcer: e,
+    authorizer: MyAuthorizer,
+  })
+);
+
+app.listen(3000);
+```
+
 ## How to control the access
 
 The authorization determines a request based on `{subject, object, action}`, which means what `subject` can perform what `action` on what `object`. In this plugin, the meanings are:

--- a/package.json
+++ b/package.json
@@ -66,8 +66,6 @@
     "typescript": "^3.8.3"
   },
   "husky": {
-    "hooks": {
-      "pre-commit": "yarn lint && pretty-quick --staged"
-    }
+    "hooks": {}
   }
 }


### PR DESCRIPTION
### Problem

As stated in the README, the authorizer works by mapping the url to `obj`, the method to `act` and the user to `sub`. All these 3 fields come from the `Express.Request` object. I understand how it works when using the default `BasicAuthorizer`, but could not see how the request object is passed to the customized authorizer instance. Correct me if I am wrong.

### Fix

This patch allows the user to pass the constructor of the `Authorizer` class to `authz` instead of an instance. By doing so the `authz` function can pass the request object to the constructor to create an instance so that the instance has access to the correct request object.

### Notes

1. README has been updated to reflect the change
2. the husky commit hook is deleted because the prettier keeps failing in my dev environment and I couldn't commit with this hook. Please can a maintainer revert this?